### PR TITLE
Change name of github actions test job

### DIFF
--- a/.github/workflows/tests.js.yml
+++ b/.github/workflows/tests.js.yml
@@ -11,6 +11,7 @@ on:
 
 jobs:
   build:
+    name: Tests
     runs-on: ubuntu-latest
     strategy:
       matrix:


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/46f4d4ab-f1d2-487c-b30d-2f1e434dac63)
Change build (22.x) to tests. Should make the name more descriptive in discord