### PR TITLE
44 make undo and edit command display result in an embed instead of just a message of success

### DIFF
--- a/commands/global/editLog.js
+++ b/commands/global/editLog.js
@@ -7,6 +7,7 @@ const {
 } = require('discord.js');
 const mongoose = require('mongoose');
 const Log = require('../../models/Log');
+const {buildLogEmbed} = require('../../utils/buildLogEmbed.js');
 
 const MAX_EPISODES = 57;
 const MAX_MINUTES = 1200;
@@ -322,18 +323,20 @@ module.exports = {
                 if (i.customId === 'confirm_edit') {
                     // User confirmed the edit
                     await log.save();
+                    const logEmbed = buildLogEmbed(interaction, log);
                     await i.update({
                         content: `✅ Log: **${log.title}** has been edited successfully.`,
                         components: [],
-                        embeds: [],
+                        embeds: [logEmbed],
                     });
                 } else if (i.customId === 'cancel_edit') {
                     // User canceled the edit
+                    const logEmbed = buildLogEmbed(interaction, log);
                     await i.update({
                         content:
                             '❌ Edit canceled. No changes were made to the log.',
                         components: [],
-                        embeds: [],
+                        embeds: [logEmbed],
                     });
                 }
                 collector.stop();

--- a/commands/global/editLog.js
+++ b/commands/global/editLog.js
@@ -323,20 +323,21 @@ module.exports = {
                 if (i.customId === 'confirm_edit') {
                     // User confirmed the edit
                     await log.save();
-                    const logEmbed = buildLogEmbed(interaction, log);
+                    const logEmbed = buildLogEmbed(interaction, log, {
+                        title: `✅ Log: **${log.title}** has been edited successfully.`
+                    });
                     await i.update({
-                        content: `✅ Log: **${log.title}** has been edited successfully.`,
+                        content: ``,
                         components: [],
                         embeds: [logEmbed],
                     });
                 } else if (i.customId === 'cancel_edit') {
                     // User canceled the edit
-                    const logEmbed = buildLogEmbed(interaction, log);
                     await i.update({
                         content:
                             '❌ Edit canceled. No changes were made to the log.',
                         components: [],
-                        embeds: [logEmbed],
+                        embeds: [],
                     });
                 }
                 collector.stop();

--- a/commands/global/undo.js
+++ b/commands/global/undo.js
@@ -1,6 +1,7 @@
-const { SlashCommandBuilder } = require('discord.js');
+const { SlashCommandBuilder, EmbedBuilder, Colors } = require('discord.js');
+const { logToCommandConverter } = require('../../utils/logToCommandConverter');
 const Log = require('../../models/Log');
-
+const User = require('../../models/User');
 
 module.exports = {
     data: new SlashCommandBuilder()
@@ -8,16 +9,39 @@ module.exports = {
         .setDescription('Removes your most recent log (cannot be undone)'),
     async execute(interaction) {
         // Determine which guildId to search for
-
         // Fetch the most recent log by the user with the determined guildId
         const log = await Log.findOne({ userId: interaction.user.id }).sort({ timestamp: -1 });
-
+        const user = await User.findOne({ userId: interaction.user.id });
+        const iconURL = interaction.user.displayAvatarURL();
         // If there is a log, delete it
-        if(log) {
+        if (log) {
             await Log.deleteOne({ _id: log._id });
-            await interaction.reply('Your most recent log has been removed.');
+            const embed = new EmbedBuilder()
+                .setColor(Colors.Blue)
+                .setTitle('Your most recent log has been removed')
+                .setDescription('Execute the following command to add the log again')
+                .setTimestamp()
+                .setFields([
+                    {
+                        name: 'command',
+                        value: `${logToCommandConverter(log, user?.timezone ?? 'UTC')}`
+                    }
+                ])
+                .setFooter({
+                    text: 'Keep up the good work!',
+                    iconURL
+                });
+            await interaction.reply({ embeds: [embed] });
         } else {
-            await interaction.reply('You have no logs to remove.');
+            const embed = new EmbedBuilder()
+                .setColor(Colors.Orange)
+                .setTimestamp()
+                .setFooter({
+                    text: `test footer`,
+                    iconURL
+                })
+                .setTitle('You have no logs to remove.');
+            await interaction.reply({ embeds: [embed] });
         }
     },
 };

--- a/test/commands/__snapshots__/editLog.test.js.snap
+++ b/test/commands/__snapshots__/editLog.test.js.snap
@@ -1,0 +1,17 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`should return error when log not found by id 1`] = `
+[MockFunction spy] {
+  "calls": [
+    [
+      "❌ \`Invalid log ID provided.\`",
+    ],
+  ],
+  "results": [
+    {
+      "type": "return",
+      "value": undefined,
+    },
+  ],
+}
+`;

--- a/test/commands/__snapshots__/log.test.js.snap
+++ b/test/commands/__snapshots__/log.test.js.snap
@@ -24,8 +24,33 @@ exports[`should send embed after saving log 1`] = `
   "calls": [
     [
       {
-        "content": "\`❌ Invalid input format. Examples: \`2ep\`, \`1h3m\`. See \`/help log\` for more info.\`",
-        "ephemeral": true,
+        "embeds": [
+          {
+            "color": 16252927,
+            "description": "1 point/min → +2 points",
+            "fields": [
+              {
+                "inline": true,
+                "name": "📖 Title",
+                "value": "Test Title",
+              },
+              {
+                "inline": true,
+                "name": "📝 Notes",
+                "value": "Some notes here",
+              },
+            ],
+            "footer": {
+              "icon_url": "http://example.com/image.jpg",
+              "text": "Keep up the great immersion!",
+            },
+            "thumbnail": {
+              "url": "http://example.com/image.jpg",
+            },
+            "timestamp": "TIMESTAMP",
+            "title": "🎉 test logged 2 minutes of Watchtime!",
+          },
+        ],
       },
     ],
   ],

--- a/test/commands/__snapshots__/undo.test.js.snap
+++ b/test/commands/__snapshots__/undo.test.js.snap
@@ -16,6 +16,22 @@ exports[`should not delete when no logs 1`] = `
 }
 `;
 
+exports[`should not undo log from other user 1`] = `
+[MockFunction spy] {
+  "calls": [
+    [
+      "You have no logs to remove.",
+    ],
+  ],
+  "results": [
+    {
+      "type": "return",
+      "value": undefined,
+    },
+  ],
+}
+`;
+
 exports[`should undo log 1`] = `
 [MockFunction spy] {
   "calls": [

--- a/test/commands/__snapshots__/undo.test.js.snap
+++ b/test/commands/__snapshots__/undo.test.js.snap
@@ -4,7 +4,19 @@ exports[`should not delete when no logs 1`] = `
 [MockFunction spy] {
   "calls": [
     [
-      "You have no logs to remove.",
+      {
+        "embeds": [
+          {
+            "color": 15105570,
+            "footer": {
+              "icon_url": "http://example.com/image.jpg",
+              "text": "test footer",
+            },
+            "timestamp": "TIMESTAMP",
+            "title": "You have no logs to remove.",
+          },
+        ],
+      },
     ],
   ],
   "results": [
@@ -20,7 +32,19 @@ exports[`should not undo log from other user 1`] = `
 [MockFunction spy] {
   "calls": [
     [
-      "You have no logs to remove.",
+      {
+        "embeds": [
+          {
+            "color": 15105570,
+            "footer": {
+              "icon_url": "http://example.com/image.jpg",
+              "text": "test footer",
+            },
+            "timestamp": "TIMESTAMP",
+            "title": "You have no logs to remove.",
+          },
+        ],
+      },
     ],
   ],
   "results": [
@@ -36,7 +60,26 @@ exports[`should undo log 1`] = `
 [MockFunction spy] {
   "calls": [
     [
-      "Your most recent log has been removed.",
+      {
+        "embeds": [
+          {
+            "color": 3447003,
+            "description": "Execute the following command to add the log again",
+            "fields": [
+              {
+                "name": "command",
+                "value": "/log medium: Watchtime amount: 1s title: Test Title notes: Some notes here",
+              },
+            ],
+            "footer": {
+              "icon_url": "http://example.com/image.jpg",
+              "text": "Keep up the good work!",
+            },
+            "timestamp": "TIMESTAMP",
+            "title": "Your most recent log has been removed",
+          },
+        ],
+      },
     ],
   ],
   "results": [

--- a/test/commands/__snapshots__/undo.test.js.snap
+++ b/test/commands/__snapshots__/undo.test.js.snap
@@ -1,0 +1,33 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`should not delete when no logs 1`] = `
+[MockFunction spy] {
+  "calls": [
+    [
+      "You have no logs to remove.",
+    ],
+  ],
+  "results": [
+    {
+      "type": "return",
+      "value": undefined,
+    },
+  ],
+}
+`;
+
+exports[`should undo log 1`] = `
+[MockFunction spy] {
+  "calls": [
+    [
+      "Your most recent log has been removed.",
+    ],
+  ],
+  "results": [
+    {
+      "type": "return",
+      "value": undefined,
+    },
+  ],
+}
+`;

--- a/test/commands/editLog.test.js
+++ b/test/commands/editLog.test.js
@@ -1,15 +1,15 @@
 import { expect } from 'vitest';
 import { execute } from '../../commands/global/editLog';
 import Log from '../../models/Log';
-import {myTest, createMockInteraction} from '../fixtures';
+import {myTest} from '../fixtures';
 
 myTest('should return error when log not found by id', async ({ interaction }) => {
     await execute(interaction);
     expect(interaction.editReply).toMatchSnapshot();
 });
 
-myTest('should edit log', async ({ log, interaction }) => {
-    let editInteraction = createMockInteraction({
+myTest('should edit log', async ({ log, interaction, createInteraction }) => {
+    let editInteraction = createInteraction({
         log_id: log.id,
         title: 'new title'
     });
@@ -22,8 +22,8 @@ myTest('should edit log', async ({ log, interaction }) => {
     expect(editedLog.title).toBe('new title');
 });
 
-myTest('should cancel edit log', async ({log, interaction}) => {
-    let editInteraction = createMockInteraction({
+myTest('should cancel edit log', async ({log, interaction, createInteraction}) => {
+    let editInteraction = createInteraction({
         log_id: log.id,
         title: 'new title'
     });

--- a/test/commands/editLog.test.js
+++ b/test/commands/editLog.test.js
@@ -1,0 +1,49 @@
+import { expect } from 'vitest';
+import { execute } from '../../commands/global/editLog';
+import Log from '../../models/Log';
+import {myTest, createMockInteraction} from '../fixtures';
+
+myTest('should return error when log not found by id', async ({ interaction }) => {
+    await execute(interaction);
+    expect(interaction.editReply).toMatchSnapshot();
+});
+
+myTest('should edit log', async ({ log, interaction }) => {
+    let editInteraction = createMockInteraction({
+        log_id: log.id,
+        title: 'new title'
+    });
+    editInteraction.user = interaction.user;
+    editInteraction.guild = interaction.guild;
+
+    await execute(editInteraction);
+    await confirmEdit(editInteraction);
+    const editedLog = await Log.findById(log._id);
+    expect(editedLog.title).toBe('new title');
+});
+
+myTest('should cancel edit log', async ({log, interaction}) => {
+    let editInteraction = createMockInteraction({
+        log_id: log.id,
+        title: 'new title'
+    });
+    editInteraction.user = interaction.user;
+    editInteraction.guild = interaction.guild;
+
+    await execute(editInteraction);
+    await cancelEdit(editInteraction);
+    const editedLog = await Log.findById(log._id);
+    expect(editedLog.title).toBe(log.title);
+});
+
+async function confirmEdit(interaction) {
+    const collector = interaction.channel.createMessageComponentCollector();
+    const collectorHandler = collector.on.mock.calls[0][1];
+    await collectorHandler({ customId: 'confirm_edit', update: vi.fn() });
+}
+
+async function cancelEdit(interaction) {
+    const collector = interaction.channel.createMessageComponentCollector();
+    const collectorHandler = collector.on.mock.calls[0][1];
+    await collectorHandler({ customId: 'cancel_edit', update: vi.fn() });
+}

--- a/test/commands/log.test.js
+++ b/test/commands/log.test.js
@@ -1,62 +1,23 @@
 import logCommand from '../../commands/global/log';
 import Log from '../../models/Log';
 import User from '../../models/User';
+import {myTest} from '../fixtures';
 
-const defaultOptions = {
-    medium: 'Watchtime',
-    amount: '120s',
-    title: 'Test Title',
-    notes: 'Some notes here',
-    episode_length: '30',
-};
-
-const saveLog = vi.fn();
-const createMockInteraction = (options = defaultOptions) => ({
-    options: {
-        getString: vi.fn((name) => options[name] || null),
-    },
-    member: {
-        displayName: 'test',
-        displayAvatarURL: () => 'http://example.com/image.jpg'
-    },
-    user: {
-        id: generateRandomId(),
-        displayName: 'test',
-        displayAvatarURL: () => 'http://example.com/image.jpg'
-    },
-    guild: {
-        id: generateRandomId()
-    },
-    reply: vi.fn(), // Mock reply method to capture responses
-    editReply: vi.fn(), // Mock reply method to capture responses
-});
-
-test('should fail on invalid time pattern', async () => {
-    const interaction = createMockInteraction({
-        ...defaultOptions,
-        medium: 'WatchTime',
-        amount: '10',
-    });
-    await logCommand.execute(interaction, saveLog);
-    expectCalledOnceWithSnapshot(interaction.reply);
-});
-
-test('should send embed after saving log', async () => {
-    const interaction = createMockInteraction({
-        ...defaultOptions,
-        amount: '2'
-    });
+myTest('should fail on invalid time pattern', async ({interaction}) => {
+    interaction.setOption('medium', 'WatchTime');
+    interaction.setOption('amount', '10');
     await logCommand.execute(interaction);
     expectCalledOnceWithSnapshot(interaction.reply);
 });
 
-test('should save log', async () => {
-    const amount = 300;
-    const interaction = createMockInteraction({
-        ...defaultOptions,
-        amount: `${amount}s`
-    });
+myTest('should send embed after saving log', async ({interaction}) => {
+    await logCommand.execute(interaction);
+    expectCalledOnceWithSnapshot(interaction.reply);
+});
 
+myTest('should save log', async ({interaction}) => {
+    const amount = 100;
+    interaction.setOption('amount', `${amount}s`);
     await logCommand.execute(interaction);
     const createdLog = await Log.findOne({ userId: interaction.user.id, guildId: interaction.guild.id });
     expect(createdLog).not.toBeNull('No log could be find. It probably was not created');
@@ -67,15 +28,14 @@ test('should save log', async () => {
                 totalSeconds: amount,
                 unit: 'Seconds'
             },
-            medium: defaultOptions.medium,
-            notes: defaultOptions.notes,
-            title: defaultOptions.title
+            medium: interaction.options.getString('medium'),
+            notes: interaction.options.getString('notes'),
+            title: interaction.options.getString('title')
         })
     );
 });
 
-test('should save user on new log', async () => {
-    const interaction = createMockInteraction();
+myTest('should save user on new log', async ({interaction}) => {
     await logCommand.execute(interaction);
     const createdUser = await User.findOne({ userId: interaction.user.id });
     expect(createdUser._doc).toEqual(

--- a/test/commands/undo.test.js
+++ b/test/commands/undo.test.js
@@ -1,0 +1,16 @@
+import {myTest} from '../fixtures';
+import {execute} from '../../commands/global/undo';
+import { expect } from 'vitest';
+import Log from '../../models/Log';
+
+myTest('should not delete when no logs', async ({interaction}) => {
+    await execute(interaction);
+    expect(interaction.reply).toMatchSnapshot();
+});
+
+myTest('should undo log', async ({log, interaction}) => {
+    await execute(interaction);
+    expect(interaction.reply).toMatchSnapshot();
+    const deletedLog = await Log.findById(log._id);
+    expect(deletedLog).toBeNull();
+});

--- a/test/commands/undo.test.js
+++ b/test/commands/undo.test.js
@@ -1,29 +1,38 @@
-import {myTest} from '../fixtures';
-import {execute} from '../../commands/global/undo';
+import { myTest } from '../fixtures';
+import { execute } from '../../commands/global/undo';
 import { expect } from 'vitest';
 import Log from '../../models/Log';
 
-myTest('should not delete when no logs', async ({interaction}) => {
+myTest('should not delete when no logs', async ({ interaction }) => {
     await execute(interaction);
     expect(interaction.reply).toMatchSnapshot();
 });
 
-myTest('should undo log', async ({log, interaction}) => {
+myTest('should undo log', async ({ log, interaction }) => {
     await execute(interaction);
     expect(interaction.reply).toMatchSnapshot();
     const deletedLog = await Log.findById(log._id);
     expect(deletedLog).toBeNull();
 });
 
-myTest('should undo only most recent log', async ({createLog, interaction}) => {
-    const oldLog = await createLog(interaction);
-    const newLog = await createLog(interaction)
+myTest('should undo only most recent log', async ({createLog, interaction }) => {
+    const oldLog = await createLog(interaction, {
+        totalSeconds: 1000,
+        count: 1,
+        unit: 'Seconds'
+    });
+    const newLog = await createLog(interaction, {
+        totalSeconds: 300,
+        count: 1,
+        unit: 'Seconds'
+    });
+
     await execute(interaction);
     expect(await Log.findById(oldLog._id)).not.toBeNull();
     expect(await Log.findById(newLog._id)).toBeNull();
 });
 
-myTest('should not undo log from other user', async ({log, interaction}) => {
+myTest('should not undo log from other user', async ({ log, interaction }) => {
     interaction.user.id = 'another-user';
     await execute(interaction);
     expect(await Log.findById(log._id)).not.toBeNull();

--- a/test/commands/undo.test.js
+++ b/test/commands/undo.test.js
@@ -14,3 +14,18 @@ myTest('should undo log', async ({log, interaction}) => {
     const deletedLog = await Log.findById(log._id);
     expect(deletedLog).toBeNull();
 });
+
+myTest('should undo only most recent log', async ({createLog, interaction}) => {
+    const oldLog = await createLog(interaction);
+    const newLog = await createLog(interaction)
+    await execute(interaction);
+    expect(await Log.findById(oldLog._id)).not.toBeNull();
+    expect(await Log.findById(newLog._id)).toBeNull();
+});
+
+myTest('should not undo log from other user', async ({log, interaction}) => {
+    interaction.user.id = 'another-user';
+    await execute(interaction);
+    expect(await Log.findById(log._id)).not.toBeNull();
+    expect(interaction.reply).toMatchSnapshot();
+});

--- a/test/fixtures.js
+++ b/test/fixtures.js
@@ -1,0 +1,77 @@
+import Log from '../models/Log';
+import { test } from 'vitest';
+
+export const myTest = test.extend({
+    interaction: async({}, use) => {
+        await use(createMockInteraction());
+    },
+    log: async ({ interaction }, use) => {
+        const newLog = new Log({
+            userId: interaction.user.id,
+            guildId: interaction.guild.id,
+            timestamp: new Date(),
+            medium: interaction.options.getString('medium'),
+            title: interaction.options.getString('title'),
+            notes: interaction.options.getString('notes'),
+            isBackLog: false,
+            amount: {
+                totalSeconds: 10,
+                count: 1,
+                unit: 'Seconds'
+            },
+        });
+        await newLog.save();
+        await use(newLog);
+    },
+});
+
+export function createMockInteraction(options) {
+    const defaultOptions = {
+        medium: 'Watchtime',
+        amount: '120s',
+        title: 'Test Title',
+        notes: 'Some notes here',
+        episode_length: '30',
+    };
+
+    options = options ?? defaultOptions;
+    const interaction = {
+        options: {
+            getString: vi.fn((name) => options[name] || null),
+        },
+        setOption: (name, value) => {
+            options[name] = value;
+        },
+        member: {
+            displayName: 'test',
+            displayAvatarURL: () => 'http://example.com/image.jpg'
+        },
+        user: {
+            id: generateRandomId(),
+            displayName: 'test',
+            displayAvatarURL: () => 'http://example.com/image.jpg'
+        },
+        guild: {
+            id: generateRandomId()
+        },
+        reply: vi.fn(), // Mock reply method to capture responses
+        editReply: vi.fn(), // Mock reply method to capture responses,
+        deferReply: vi.fn(), // Mock reply method to capture responses,
+        channel: {
+            createMessageComponentCollector: vi.fn()
+        }
+    };
+
+    // Mock collector
+    const mockCollector = {
+        on: vi.fn(),
+        stop: vi.fn()
+    };
+
+    interaction.channel.createMessageComponentCollector.mockReturnValue(mockCollector);
+    return interaction;
+};
+
+function generateRandomId(length = 10) {
+    return Math.random().toString(36).substring(2, length); // Generate a random string of specified length
+}

--- a/test/fixtures.js
+++ b/test/fixtures.js
@@ -2,26 +2,33 @@ import Log from '../models/Log';
 import { test } from 'vitest';
 
 export const myTest = test.extend({
-    interaction: async({}, use) => {
+    interaction: async ({ }, use) => {
         await use(createMockInteraction());
     },
-    log: async ({ interaction }, use) => {
-        const newLog = new Log({
-            userId: interaction.user.id,
-            guildId: interaction.guild.id,
-            timestamp: new Date(),
-            medium: interaction.options.getString('medium'),
-            title: interaction.options.getString('title'),
-            notes: interaction.options.getString('notes'),
-            isBackLog: false,
-            amount: {
-                totalSeconds: 10,
-                count: 1,
-                unit: 'Seconds'
-            },
+    createInteraction: async ({}, use) => await use(createMockInteraction),
+    createLog: async ({}, use) => {
+        return use(async (interaction) => {
+            const newLog = new Log({
+                userId: interaction.user.id,
+                guildId: interaction.guild.id,
+                timestamp: new Date(),
+                medium: interaction.options.getString('medium'),
+                title: interaction.options.getString('title'),
+                notes: interaction.options.getString('notes'),
+                isBackLog: false,
+                amount: {
+                    totalSeconds: 10,
+                    count: 1,
+                    unit: 'Seconds'
+                },
+            });
+            await newLog.save();
+            return newLog;
         });
-        await newLog.save();
-        await use(newLog);
+    },
+    log: async ({ createLog, interaction }, use) => {
+        const log = await createLog(interaction);
+        await use(log);
     },
 });
 

--- a/test/utils/__snapshots__/logToCommandConverter.test.js.snap
+++ b/test/utils/__snapshots__/logToCommandConverter.test.js.snap
@@ -1,0 +1,13 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`should convert anime command 1`] = `"/log medium: Anime amount: 2ep title: Anime test notes: Anime note episode_length: 2000s"`;
+
+exports[`should convert listening command 1`] = `"/log medium: Listening amount: 1s title: listening test notes: listening note"`;
+
+exports[`should convert manga command 1`] = `"/log medium: Manga amount: 1s title: Manga test notes: Manga note"`;
+
+exports[`should convert readtime command 1`] = `"/log medium: Readtime amount: 1s title: Readtime test notes: Readtime note"`;
+
+exports[`should convert watchtime command 1`] = `"/log medium: Watchtime amount: 1s title: WatchTime test notes: WatchTime note"`;
+
+exports[`should convert youtube command 1`] = `"/log medium: YouTube amount: 1s title: YouTube test notes: YouTube note"`;

--- a/test/utils/logToCommandConverter.test.js
+++ b/test/utils/logToCommandConverter.test.js
@@ -1,0 +1,15 @@
+import {myTest} from '../fixtures';
+import { logToCommandConverter } from '../../utils/logToCommandConverter';
+import { expect } from 'vitest';
+
+myTest('should convert listening command', ({listeningLog}) => runSnapshotTest(listeningLog));
+myTest('should convert watchtime command', ({watchtimeLog}) => runSnapshotTest(watchtimeLog));
+myTest('should convert readtime command', ({readtimeLog}) => runSnapshotTest(readtimeLog));
+myTest('should convert youtube command', ({youTubeLog}) => runSnapshotTest(youTubeLog));
+myTest('should convert manga command', ({mangaLog}) => runSnapshotTest(mangaLog));
+myTest('should convert anime command', ({animeLog}) => runSnapshotTest(animeLog));
+
+const runSnapshotTest = (log) => {
+    const command = logToCommandConverter(log);
+    expect(command).toMatchSnapshot();
+}

--- a/utils/buildLogEmbed.js
+++ b/utils/buildLogEmbed.js
@@ -2,9 +2,10 @@ const { footerCreator } = require('./formatting/logFooterCreator.js');
 const { calculateEmbedColor } = require('./formatting/calculateEmbedColor.js');
 const { EmbedBuilder } = require('discord.js');
 
-// Utility function to create and send the embed message
-function buildLogEmbed(interaction, log) {
+// Utility function to create the embed message
+function buildLogEmbed(interaction, log, overrides) {
     // Calculate title and description for embed
+    let embedTitle = overrides?.title;
     const unit = log.amount.unit;
     const totalSeconds = log.amount.totalSeconds;
     const count = log.amount.count;
@@ -16,11 +17,12 @@ function buildLogEmbed(interaction, log) {
     const description = unit === "Episodes"
         ? `${Math.round((coefficient * 10) / 60) / 10} minutes/episode → +${Math.round((totalSeconds * 10) / 60) / 10} points`
         : `1 point/min → +${Math.round((totalSeconds * 10) / 60) / 10} points`;
-    let embedTitle = `🎉 ${interaction.member.displayName} logged ${count} ${unit} of ${medium}!`;
-    if (unit !== "Episodes") {
-        embedTitle = `🎉 ${interaction.member.displayName} logged ${Math.round((totalSeconds * 10) / 60) / 10} minutes of ${medium}!`;
+    if (!embedTitle) {
+        embedTitle = `🎉 ${interaction.member.displayName} logged ${count} ${unit} of ${medium}!`;
+        if (unit !== "Episodes") {
+            embedTitle = `🎉 ${interaction.member.displayName} logged ${Math.round((totalSeconds * 10) / 60) / 10} minutes of ${medium}!`;
+        }
     }
-
 
     // Calculate the embed color based on the points
     const embedColor = calculateEmbedColor(totalSeconds);

--- a/utils/buildLogEmbed.js
+++ b/utils/buildLogEmbed.js
@@ -1,0 +1,41 @@
+const { footerCreator } = require('./formatting/logFooterCreator.js');
+const { calculateEmbedColor } = require('./formatting/calculateEmbedColor.js');
+const { EmbedBuilder } = require('discord.js');
+
+// Utility function to create and send the embed message
+function buildLogEmbed(interaction, log) {
+    // Calculate title and description for embed
+    const unit = log.amount.unit;
+    const totalSeconds = log.amount.totalSeconds;
+    const count = log.amount.count;
+    const medium = log.medium;
+    const notes = log.notes;
+
+    const description = unit === "Episodes"
+        ? `${Math.round((unitLength * 10) / 60) / 10} minutes/episode → +${Math.round((totalSeconds * 10) / 60) / 10} points`
+        : `1 point/min → +${Math.round((totalSeconds * 10) / 60) / 10} points`;
+    let embedTitle = `🎉 ${interaction.member.displayName} logged ${count} ${unit} of ${medium}!`;
+    if (unit !== "Episodes") {
+        embedTitle = `🎉 ${interaction.member.displayName} logged ${Math.round((totalSeconds * 10) / 60) / 10} minutes of ${medium}!`;
+    }
+    // Calculate the embed color based on the points
+    const embedColor = calculateEmbedColor(totalSeconds);
+    // Create footer message
+    const footer = footerCreator(interaction, totalSeconds);
+
+    const logEmbed = new EmbedBuilder()
+        .setColor(embedColor)
+        .setTitle(embedTitle)
+        .setDescription(description)
+        .setThumbnail(interaction.user.displayAvatarURL())
+        .addFields({ name: '📖 Title', value: log.title, inline: true })
+        .setTimestamp();
+    if (notes) {
+        logEmbed.addFields({ name: '📝 Notes', value: log.notes, inline: true });
+    }
+    logEmbed.setFooter(footer);
+
+    return logEmbed;
+}
+
+module.exports = { buildLogEmbed };

--- a/utils/logToCommandConverter.js
+++ b/utils/logToCommandConverter.js
@@ -1,0 +1,30 @@
+const { DateTime } = require('luxon');
+
+const logToCommandConverter = (logModel, timezone = 'utc') => {
+    const todayUTC = DateTime.utc().toFormat('yyyy-MM-dd');
+    const logDateWithTimezone = DateTime.fromJSDate(logModel.timestamp, { zone: timezone }).toFormat('yyyy-MM-dd');
+
+    const isSameDay = todayUTC === logDateWithTimezone;
+    let command = isSameDay ? '/log' : `/backlog  date: ${logDateWithTimezone} `;
+    const unit = convertUnitToString(logModel.amount.unit);
+    command += ` medium: ${logModel.medium} amount: ${logModel.amount.count}${unit} title: ${logModel.title}`;
+    if (logModel.notes) {
+        command += ` notes: ${logModel.notes}`;
+    }
+    if (logModel.medium === 'Anime') {
+        const unitLength = logModel.amount.unitLength;
+        command += ` episode_length: ${unitLength}s`;
+    }
+
+    return command;
+};
+
+const convertUnitToString = (unit) => {
+    if (unit === 'Episodes') {
+        return 'ep';
+    }
+
+    return 's';
+}
+
+module.exports = { logToCommandConverter }

--- a/utils/saveLog.js
+++ b/utils/saveLog.js
@@ -58,6 +58,8 @@ async function saveLog(interaction, customDate, medium, title, notes, isBackLog,
                 await existingUser.save();
             }
         }
+
+        return newLog;
     } catch (error) {
         console.error("Error saving log:", error);
         await interaction.editReply("An error occurred while saving your log.");

--- a/vitest.setup.js
+++ b/vitest.setup.js
@@ -1,8 +1,5 @@
 import { afterEach, expect } from 'vitest';
 import * as mongoose from 'mongoose';
-import Log from './models/Log';
-import User from './models/User';
-import Timeout from './models/Timeout';
 
 // replace timestamps in snapshots so they are always the same
 expect.addSnapshotSerializer({
@@ -10,23 +7,14 @@ expect.addSnapshotSerializer({
     print: () => `"TIMESTAMP"`,
 });
 
-// delete all entries in db between each test to prevent state leaking over
-afterEach(async () => {
-    await Promise.all([
-        Log.deleteMany({}),
-        User.deleteMany({}),
-        Timeout.deleteMany({}),
-        // Add more models after they are created here
-    ]);
-});
-
 // https://typegoose.github.io/mongodb-memory-server/docs/guides/integration-examples/test-runners
-beforeAll(async () => {
+beforeEach(async () => {
     // put your client connection code here, example with mongoose:
     await mongoose.connect(process.env['MONGO_URI']);
 });
 
-afterAll(async () => {
+afterEach(async () => {
     // put your client disconnection code here, example with mongoose:
+    // Makes sure each test is run in isolation
     await mongoose.disconnect();
 });

--- a/vitest.setup.js
+++ b/vitest.setup.js
@@ -7,6 +7,11 @@ expect.addSnapshotSerializer({
     print: () => `"TIMESTAMP"`,
 });
 
+expect.addSnapshotSerializer({
+    test: (val) => typeof val === 'string' && /^\d{4}-\d{2}-\d{2}$/.test(val),
+    print: () => `"DATE"`,
+});
+
 // https://typegoose.github.io/mongodb-memory-server/docs/guides/integration-examples/test-runners
 beforeEach(async () => {
     // put your client connection code here, example with mongoose:


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/97c994f0-40d1-41a4-ae0b-071bf1a01adb)

undo:

![image](https://github.com/user-attachments/assets/aa8d6b2b-9242-40a7-b76a-19fb7caf4d02)

anime also includes the episode_length in the command
![image](https://github.com/user-attachments/assets/451e9d80-dcfd-4fff-b7e0-0390ba77cd85)

added fixtures for vitest to reduce duplication:
https://vitest.dev/guide/test-context#extend-test-context